### PR TITLE
feat: 부스/푸드트럭 프리뷰/상세보기에서 헤더 안보이게

### DIFF
--- a/src/context/HeaderContext.tsx
+++ b/src/context/HeaderContext.tsx
@@ -1,0 +1,20 @@
+// src/context/HeaderContext.tsx
+import React, { createContext, useState, useContext, ReactNode } from 'react';
+
+interface HeaderContextType {
+  hideHeader: boolean;
+  setHideHeader: (value: boolean) => void;
+}
+
+const HeaderContext = createContext<HeaderContextType>({
+  hideHeader: false,
+  setHideHeader: () => {},
+});
+
+export const useHeader = () => useContext(HeaderContext);
+
+export const HeaderProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
+  const [hideHeader, setHideHeader] = useState(false);
+
+  return <HeaderContext.Provider value={{ hideHeader, setHideHeader }}>{children}</HeaderContext.Provider>;
+};

--- a/src/routes/layouts/DefaultLayout.tsx
+++ b/src/routes/layouts/DefaultLayout.tsx
@@ -3,42 +3,49 @@ import { Outlet } from 'react-router-dom';
 import { TheFooter } from '../../components/TheFooter';
 import styled from 'styled-components';
 import { MenuProvider } from '../../context/MenuContext';
+import { HeaderProvider, useHeader } from '../../context/HeaderContext';
 import TheSidebar from '../../components/TheSidebar';
 import TheHeader from '../../components/TheHeader';
 
-export const DefaultLayout = () => {
+const LayoutContent = () => {
+  const { hideHeader } = useHeader();
+
   return (
     <>
-      <AppDom>
-        <MenuProvider>
-          <TheHeader />
-          <TheSidebar />
-          <Content>
-            <Outlet />
-          </Content>
-          <TheFooter />
-        </MenuProvider>
-      </AppDom>
+      {!hideHeader && <TheHeader key="header-visible" />}
+      <TheSidebar />
+      <Content hideHeader={hideHeader}>
+        <Outlet />
+      </Content>
+      <TheFooter />
     </>
   );
 };
 
+export const DefaultLayout = () => {
+  return (
+    <AppDom>
+      <MenuProvider>
+        <HeaderProvider>
+          <LayoutContent />
+        </HeaderProvider>
+      </MenuProvider>
+    </AppDom>
+  );
+};
+
 const AppDom = styled.div`
-  width: min(100vw, 600px); // 화면 너비에 맞추면서 최대 600px로 제한
-  height: 100vh; // 웹 뷰
+  width: min(100vw, 600px);
+  height: 100vh;
   margin: 0 auto;
+  font-family: 'Pretendard-Regular';
 
   @media (max-width: 600px) {
     width: 100vw;
     height: calc(var(--vh, 1vh) * 100);
   }
-
-  font-family: 'Pretendard-Regular';
-  // display: flex;
-  // flex-direction: column;
-  // justify-content: center;
 `;
 
-const Content = styled.div`
-  padding: 60px 0px 60px 0px; // 상단 헤더와 하단 푸터를 제외한 여백
+const Content = styled.div<{ hideHeader: boolean }>`
+  padding: ${({ hideHeader }) => (hideHeader ? '0px' : '60px')} 0px 60px 0px;
 `;

--- a/src/routes/pages/booth/BoothDetail.tsx
+++ b/src/routes/pages/booth/BoothDetail.tsx
@@ -6,10 +6,12 @@ import { BaseLayer } from '../../../components/BottomSheet/layout/BaseLayer';
 import { GoBackButton } from '../../../components/common/GoBackButton';
 import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import { BoothDetailRawData, fetchBoothDetail } from '../../../services/apis/booth/boothDetail';
+import { useHeader } from '../../../context/HeaderContext';
 
 export const BoothDetail = () => {
   const navigate = useNavigate();
   const location = useLocation();
+  const { setHideHeader } = useHeader();
   const { dayBoothNum } = useParams<{ dayBoothNum: string }>();
   const [boothDetail, setBoothDetail] = useState<BoothDetailRawData | null>(null);
   const selectedDate = location.state?.selectedDate;
@@ -22,6 +24,11 @@ export const BoothDetail = () => {
     };
     getBoothDetail();
   }, [dayBoothNum, selectedDate]);
+
+  useEffect(() => {
+    setHideHeader(true);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   if (!boothDetail) {
     return <div>Loading...</div>;

--- a/src/routes/pages/booth/index.tsx
+++ b/src/routes/pages/booth/index.tsx
@@ -10,8 +10,10 @@ import { StaticBottomSheet } from '../../../components/BottomSheet/variants/Stat
 import { ItemPreviewContent } from '../../../components/BottomSheet/innerContent/ItemPreviewContent';
 import { GoBackButton } from '../../../components/common/GoBackButton';
 import { fetchBoothList } from '../../../services/apis/booth/boothList';
+import { useHeader } from '../../../context/HeaderContext';
 
 export const Booth = () => {
+  const { setHideHeader } = useHeader();
   const [selectedDate, setSelectedDate] = useState<Option>(dateOptions[0]);
   const [selectedPlace, setSelectedPlace] = useState<Option>(placeOptions[0]);
   const [selectedItem, setSelectedItem] = useState<BoothOrFoodTruckItem | null>(null);
@@ -30,8 +32,13 @@ export const Booth = () => {
     getBoothList();
   }, [selectedDate]);
 
+  useEffect(() => {
+    setHideHeader(!!selectedItem);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedItem]);
+
   return (
-    <BaseLayer>
+    <BaseLayer backgroundImgSrc="1.png">
       {/* 리스트 바텀시트 */}
       {!selectedItem && (
         <>
@@ -84,6 +91,6 @@ const OptionContainer = styled.div`
 
 const GoBackButtonContainer = styled.div`
   position: absolute;
-  left: 7px;
+  left: 15px;
   top: 20px;
 `;

--- a/src/routes/pages/foodTruck/FoodTruckDetail.tsx
+++ b/src/routes/pages/foodTruck/FoodTruckDetail.tsx
@@ -6,8 +6,10 @@ import { StaticBottomSheet } from '../../../components/BottomSheet/variants/Stat
 import { FoodTruckDetailContent } from '../../../components/BottomSheet/innerContent/FoodTruckDetailContent';
 import styled from 'styled-components';
 import { fetchFoodTruckDetail, FoodTruckDetailRawData } from '../../../services/apis/foodTruck/foodTruckDetail';
+import { useHeader } from '../../../context/HeaderContext';
 
 export const FoodTruckDetail = () => {
+  const { setHideHeader } = useHeader();
   const navigate = useNavigate();
   const location = useLocation();
   const { dayFoodTruckNum } = useParams<{ dayFoodTruckNum: string }>();
@@ -23,13 +25,18 @@ export const FoodTruckDetail = () => {
     getFoodTruckDetail();
   }, [dayFoodTruckNum, selectedDate]);
 
+  useEffect(() => {
+    setHideHeader(true);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   if (!foodTruckDetail) {
     return <div>loading...</div>;
   }
 
   return (
     <>
-      <BaseLayer backgroundImgSrc={foodTruckDetail.cover}>
+      <BaseLayer backgroundImgSrc={foodTruckDetail?.cover}>
         <GoBackButtonContainer>
           <GoBackButton onClick={() => navigate(-1)} />
         </GoBackButtonContainer>

--- a/src/routes/pages/foodTruck/index.tsx
+++ b/src/routes/pages/foodTruck/index.tsx
@@ -10,8 +10,10 @@ import { GoBackButton } from '../../../components/common/GoBackButton';
 import { StaticBottomSheet } from '../../../components/BottomSheet/variants/StaticBottomSheet';
 import { ItemPreviewContent } from '../../../components/BottomSheet/innerContent/ItemPreviewContent';
 import { fetchFoodTruckList } from '../../../services/apis/foodTruck/foodTruckList';
+import { useHeader } from '../../../context/HeaderContext';
 
 export const FoodTruck = () => {
+  const { setHideHeader } = useHeader();
   const [selectedDate, setSelectedDate] = useState<Option>(dateOptions[0]);
   const [selectedPlace, setSelectedPlace] = useState<Option>(placeOptions[0]);
   const [selectedItem, setSelectedItem] = useState<BoothOrFoodTruckItem | null>(null);
@@ -29,6 +31,12 @@ export const FoodTruck = () => {
     };
     getFoodTruckList();
   }, [selectedDate]);
+
+  // 헤더 안보이도록
+  useEffect(() => {
+    setHideHeader(!!selectedItem);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedItem]);
 
   return (
     <BaseLayer>
@@ -81,6 +89,6 @@ export const OptionContainer = styled.div`
 
 const GoBackButtonContainer = styled.div`
   position: absolute;
-  left: 7px;
+  left: 15px;
   top: 20px;
 `;


### PR DESCRIPTION
## 🔀 Pull Request Title

간결하고 명확한 제목 작성 (예: `feat: 로그인 기능 구현`)

---

## 📌 Description

- 부스/푸드트럭 프리뷰 & 상세보기에서 헤더 안보이도록

---

## ✅ Checklist

- [x] prettier
- [x] 새로 설치한 라이브러리가 있다면 작성하였나요?

---

## 📷 Screenshots (if applicable)

If there are UI changes, please include relevant screenshots.
UI 변경이 있을 경우 스크린샷을 첨부해주세요.

---

## 🔍 Additional Notes

## ‼️ 헤더안보이도록 설정하려면...

1. context 가져오기
  `const { setHideHeader } = useHeader();`

2. 안보이도록 설정할 페이지에 useEffect로 false로 만들기 
~~~
useEffect(() => {
    setHideHeader(true);
    // eslint-disable-next-line react-hooks/exhaustive-deps
  }, []);
~~~~
